### PR TITLE
Implementación en pantalla "ver solución" en LessonPage

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1548,6 +1548,62 @@ button.profile-icon-chip:hover {
   transform: translateY(-1px);
 }
 
+.lesson-solution-btn {
+  padding: 14px 32px;
+  border: 2px solid #f59e0b;
+  border-radius: 12px;
+  background: #fffbeb;
+  color: #b45309;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s, background 0.2s;
+}
+
+.lesson-solution-btn:hover:not(:disabled) {
+  background: #fef3c7;
+  transform: translateY(-1px);
+}
+
+.lesson-solution-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.lesson-solution-panel {
+  margin-top: 24px;
+  text-align: left;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px 24px;
+}
+
+.solution-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin-bottom: 10px;
+}
+
+.solution-explanation {
+  font-size: 0.9rem;
+  color: #4b5563;
+  margin-bottom: 14px;
+  line-height: 1.6;
+}
+
+.solution-code {
+  background: #1e293b;
+  color: #e2e8f0;
+  border-radius: 8px;
+  padding: 16px;
+  font-size: 0.875rem;
+  overflow-x: auto;
+  white-space: pre;
+  line-height: 1.6;
+}
+
 /* Exercise styles */
 .exercise-header {
   margin-bottom: 24px;

--- a/src/pages/LessonPage.jsx
+++ b/src/pages/LessonPage.jsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import MotionPage from '../components/MotionPage'
 import { useLanguage } from '../context/useLanguage'
-import { getLessonContent, submitLessonExercise, submitLessonSolution } from '../services/learningApi'
+import { getLessonContent, getLessonSolution, submitLessonExercise, submitLessonSolution } from '../services/learningApi'
 import { notifyError, notifyInfo, notifySuccess } from '../utils/notify'
 
 // Bonus XP que se otorga por completar la lección perfecta en un reintento
@@ -27,6 +27,11 @@ function LessonPage() {
   const [errorsInAttempt, setErrorsInAttempt] = useState(0)
   const [isRetry, setIsRetry] = useState(false)
   const [bonusAwarded, setBonusAwarded] = useState(false)
+
+  // Estado de la solución oficial
+  const [solution, setSolution] = useState(null)
+  const [showSolution, setShowSolution] = useState(false)
+  const [loadingSolution, setLoadingSolution] = useState(false)
 
   const loadLesson = useCallback(async () => {
     setLoading(true)
@@ -60,6 +65,23 @@ function LessonPage() {
     resetAttempt()
     setIsRetry(true)
     setCurrentStep('exercise')
+  }
+
+  const handleViewSolution = async () => {
+    if (solution) {
+      setShowSolution((prev) => !prev)
+      return
+    }
+    setLoadingSolution(true)
+    try {
+      const data = await getLessonSolution(Number(lessonId))
+      setSolution(data)
+      setShowSolution(true)
+    } catch (e) {
+      notifyError(e?.message || 'No se pudo cargar la solución.')
+    } finally {
+      setLoadingSolution(false)
+    }
   }
 
   const currentExercise = exercises[currentExerciseIdx]
@@ -198,6 +220,16 @@ function LessonPage() {
           )}
 
           <div className="completed-actions">
+            {errorsInAttempt > 0 && (
+              <button
+                className="lesson-solution-btn ui-jitter"
+                onClick={handleViewSolution}
+                disabled={loadingSolution}
+                type="button"
+              >
+                {loadingSolution ? '⏳ Cargando...' : showSolution ? '🙈 Ocultar solución' : '💡 Ver solución'}
+              </button>
+            )}
             <button
               className="lesson-retry-btn ui-jitter"
               onClick={handleRetryLesson}
@@ -213,6 +245,18 @@ function LessonPage() {
               {t('lesson.backDashboard')}
             </button>
           </div>
+
+          {showSolution && solution && (
+            <div className="lesson-solution-panel">
+              <h3 className="solution-title">💡 Solución oficial</h3>
+              {solution.explanation && (
+                <p className="solution-explanation">{solution.explanation}</p>
+              )}
+              <pre className="solution-code">
+                <code>{solution.solved_code}</code>
+              </pre>
+            </div>
+          )}
         </div>
       </MotionPage>
     )
@@ -253,13 +297,30 @@ function LessonPage() {
 
           <div className="lesson-actions">
             {alreadyCompleted ? (
-              <button className="lesson-start-btn lesson-retry-btn ui-jitter" onClick={handleRetryLesson} type="button">
-                🔄 Repetir lección
-              </button>
+              <>
+                <button className="lesson-solution-btn ui-jitter" onClick={handleViewSolution} disabled={loadingSolution} type="button">
+                  {loadingSolution ? '⏳ Cargando...' : showSolution ? '🙈 Ocultar solución' : '💡 Ver solución'}
+                </button>
+                <button className="lesson-start-btn lesson-retry-btn ui-jitter" onClick={handleRetryLesson} type="button">
+                  🔄 Repetir lección
+                </button>
+              </>
             ) : (
               <button className="lesson-start-btn ui-jitter" onClick={handleStartExercises} type="button">
                 {exercises.length > 0 ? t('lesson.startExercises') : t('lesson.completeLesson')}
               </button>
+            )}
+
+            {showSolution && solution && (
+              <div className="lesson-solution-panel">
+                <h3 className="solution-title">💡 Solución oficial</h3>
+                {solution.explanation && (
+                  <p className="solution-explanation">{solution.explanation}</p>
+                )}
+                <pre className="solution-code">
+                  <code>{solution.solved_code}</code>
+                </pre>
+              </div>
             )}
           </div>
         </div>

--- a/src/services/learningApi.js
+++ b/src/services/learningApi.js
@@ -201,6 +201,15 @@ export async function submitLessonSolution({ lessonId, code, languageId, correct
   })
 }
 
+export async function getLessonSolution(lessonId) {
+  const normalizedLessonId = parsePositiveInt(lessonId)
+  if (!normalizedLessonId) {
+    throw new Error('La lección solicitada no es válida.')
+  }
+
+  return requestJson(`/api/learning/lessons/${normalizedLessonId}/solution`)
+}
+
 function readFavoriteLessons() {
   try {
     const raw = localStorage.getItem(STORAGE_KEYS.favoriteLessons)


### PR DESCRIPTION
## Descripción
Se implementa la funcionalidad de "ver solución" en LessonPage. El botón aparece en dos contextos: en la pantalla de resultado cuando el usuario cometió al menos un error durante su intento, y en la pantalla de teoría cuando regresa a una lección que ya completó anteriormente.
Al hacer clic se consulta GET /api/learning/lessons/:id/solution y se muestra un panel con la explicación y el código resuelto. Un segundo clic oculta el panel. Si el usuario lo hizo perfectamente, el botón no aparece — no necesita ver la solución porque ya la conoce.

## Fixes #32 

## Screenshots or videos
<img width="1865" height="938" alt="image" src="https://github.com/user-attachments/assets/aa9999fc-701b-4370-8551-5c289ae7e0eb" />

### "Sale boton "ver solucion" solo si el usuario hizo mal el ejercicio de codificar
<img width="1869" height="928" alt="image" src="https://github.com/user-attachments/assets/57b9ca4a-330d-45f5-916e-31be1cb7c754" />