### PR TITLE
Ajustar experiencia visual e i18n del demo público

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4947,6 +4947,68 @@ button:disabled {
   margin: 0;
 }
 
+.landing__auth-preview--highlights {
+  display: grid;
+  gap: 10px;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.landing__hero-side-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(9, 18, 33, 0.56);
+}
+
+.landing__hero-side-card-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(16, 29, 48, 0.74);
+  color: #86efac;
+  font-size: 1.15rem;
+  flex-shrink: 0;
+}
+
+.landing__hero-side-card:nth-child(2) .landing__hero-side-card-icon {
+  color: #c084fc;
+}
+
+.landing__hero-side-card:nth-child(3) .landing__hero-side-card-icon {
+  color: #fbbf24;
+}
+
+.landing__hero-side-card-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.landing__hero-side-card-copy strong {
+  color: #eef5ff;
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.landing__hero-side-card-copy p {
+  margin: 0;
+  max-width: none;
+  color: #9fb0c9;
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
 .landing__auth-submit {
   width: 100%;
   margin-top: 8px;


### PR DESCRIPTION
## Descripción:

Se mejora la experiencia pública del demo con soporte i18n, ajustes visuales del selector de lenguajes y mayor coherencia con el landing.

## Fixes: #112 

## Screenshots or videos:
<img width="1868" height="944" alt="image" src="https://github.com/user-attachments/assets/7a837723-f9c0-4287-ae14-5cd7269cd3d1" />